### PR TITLE
created imageSet mechanic to unify all images together for npc/character

### DIFF
--- a/src/main/java/com/efederation/Configuration/SecurityConfiguration.java
+++ b/src/main/java/com/efederation/Configuration/SecurityConfiguration.java
@@ -32,7 +32,7 @@ public class SecurityConfiguration {
                                 "/api/v1/auth/**",
                                 "/api/v1/npc/create",
                                 "/api/v1/npc/update",
-                                "/api/v1/npc/image/create"
+                                "/api/imageset/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/efederation/Constants/CommonConstants.java
+++ b/src/main/java/com/efederation/Constants/CommonConstants.java
@@ -1,6 +1,7 @@
 package com.efederation.Constants;
 
 public class CommonConstants {
+    public static final String success = "Successful";
     public static final String fromEmail = "efedbusiness@gmail.com";
     public static String npcDenotation = "n";
     public static int LIGHT_HEAVYWEIGHT_MIN_WEIGHT = 225;

--- a/src/main/java/com/efederation/Controller/ImageSetController.java
+++ b/src/main/java/com/efederation/Controller/ImageSetController.java
@@ -1,0 +1,36 @@
+package com.efederation.Controller;
+
+import com.efederation.DTO.ImageSetCreateRequest;
+import com.efederation.Exception.ApiError;
+import com.efederation.Service.ImageSetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.WebRequest;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/imageset")
+public class ImageSetController {
+
+    @Autowired
+    ImageSetService imageSetService;
+
+    @ExceptionHandler({IOException.class})
+    @ResponseBody
+    public ResponseEntity<Object> handleIOException(
+            IOException ex,
+            WebRequest webRequest) {
+        ApiError apiError = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), "An error occurred.");
+        return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+    }
+
+    @PostMapping(value = "/v1/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<String> createImageSet(@ModelAttribute ImageSetCreateRequest request) throws IOException {
+        return ResponseEntity.ok(imageSetService.createImageSet(request));
+    }
+}

--- a/src/main/java/com/efederation/Controller/NPCController.java
+++ b/src/main/java/com/efederation/Controller/NPCController.java
@@ -36,14 +36,4 @@ public class NPCController {
         npcService.updateNPCJsonAttributes(1);
         return ResponseEntity.ok().body("NPC updated!");
     }
-
-    @PostMapping(value = "/image/create", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<String> uploadImage(
-            @RequestParam("image") MultipartFile file,
-            @RequestParam("npcId") long id,
-            @RequestParam("type") ImageType uploadType
-            ) {
-        npcService.uploadImage(id, file, uploadType);
-        return ResponseEntity.ok().body("Image uploaded!");
-    }
 }

--- a/src/main/java/com/efederation/Controller/WrestlerController.java
+++ b/src/main/java/com/efederation/Controller/WrestlerController.java
@@ -77,10 +77,4 @@ public class WrestlerController {
         wrestlerService.updateWrestlerJsonAttributes(1);
         return ResponseEntity.ok().body("Wrestler updated!");
     }
-
-    @PostMapping(value = "/image/create", consumes = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<String> uploadImage(@RequestBody WrestlerImageCreateRequest imageCreateRequest) {
-        wrestlerService.uploadImage(imageCreateRequest);
-        return ResponseEntity.ok().body("Image uploaded!");
-    }
 }

--- a/src/main/java/com/efederation/DTO/ImageSetCreateRequest.java
+++ b/src/main/java/com/efederation/DTO/ImageSetCreateRequest.java
@@ -1,0 +1,17 @@
+package com.efederation.DTO;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+public class ImageSetCreateRequest {
+    private String name;
+    private MultipartFile idle;
+    private MultipartFile defeated;
+    private MultipartFile attackOne;
+    private MultipartFile attackTwo;
+    private MultipartFile attackThree;
+    private MultipartFile attackFour;
+}

--- a/src/main/java/com/efederation/DTO/SubmitCharacterRequest.java
+++ b/src/main/java/com/efederation/DTO/SubmitCharacterRequest.java
@@ -18,4 +18,5 @@ public class SubmitCharacterRequest {
     private String finishingMove;
     private float weight;
     private Attributes attributes;
+    private long imageSetId;
 }

--- a/src/main/java/com/efederation/Model/Character.java
+++ b/src/main/java/com/efederation/Model/Character.java
@@ -19,21 +19,6 @@ public abstract class Character {
     @Convert(converter = HashMapConverter.class)
     private WrestlerAttributes wrestlerAttributes;
 
-    @Lob
-    @Column(name="imagedata", length = 1000)
-    private byte[] imageData;
-
-    @Lob
-    @Column(name="defeatedImage")
-    private byte[] defeatedImage;
-
-    public void setImageProperty(ImageType type, byte[] imageData) {
-        switch(type) {
-            case MAIN -> this.imageData = imageData;
-            case DEFEATED -> this.defeatedImage = imageData;
-        }
-    }
-
     public Integer fight() {
         Random roll = new Random();
         return this.wrestlerAttributes.getSpeed() + this.wrestlerAttributes.getStrength() + roll.nextInt(20);

--- a/src/main/java/com/efederation/Model/ImageSet.java
+++ b/src/main/java/com/efederation/Model/ImageSet.java
@@ -1,0 +1,56 @@
+package com.efederation.Model;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a character entity's set of images represented in db blob form.
+ */
+@Entity
+@Getter
+@Setter
+public class ImageSet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String setName;
+
+    @Lob
+    private byte[] idleImage;
+
+    @Lob
+    private byte[] defeatedImage;
+
+    @Lob
+    private byte[] attackFrame1;
+
+    @Lob
+    private byte[] attackFrame2;
+
+    @Lob
+    private byte[] attackFrame3;
+
+    @Lob
+    private byte[] attackFrame4;
+
+    public ImageSet() {
+        super();
+    }
+
+    @Builder
+    public ImageSet(String setName, byte[] idleImage, byte[] defeatedImage, byte[] attackFrame1,
+                    byte [] attackFrame2, byte[] attackFrame3, byte [] attackFrame4) {
+        this.setName = setName;
+        this.idleImage = idleImage;
+        this.defeatedImage = defeatedImage;
+        this.attackFrame1 = attackFrame1;
+        this.attackFrame2 = attackFrame2;
+        this.attackFrame3 = attackFrame3;
+        this.attackFrame4 = attackFrame4;
+    }
+}

--- a/src/main/java/com/efederation/Model/NPC.java
+++ b/src/main/java/com/efederation/Model/NPC.java
@@ -24,11 +24,16 @@ public class NPC extends Character{
     )
     private Set<Match> matches;
 
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name="imageSetId", referencedColumnName = "id")
+    private ImageSet imageSet;
+
     @CreationTimestamp
     private Timestamp createdAt;
 
     @Builder
-    public NPC(String announceName, String firstName, String lastName, WrestlerAttributes wrestlerAttributes, byte[] imageData, byte[] defeatedImage) {
-        super(announceName, firstName, lastName, wrestlerAttributes, imageData, defeatedImage);
+    public NPC(String announceName, String firstName, String lastName, WrestlerAttributes wrestlerAttributes, ImageSet imageSet) {
+        super(announceName, firstName, lastName, wrestlerAttributes);
+        this.imageSet = imageSet;
     }
 }

--- a/src/main/java/com/efederation/Model/Wrestler.java
+++ b/src/main/java/com/efederation/Model/Wrestler.java
@@ -31,17 +31,22 @@ public class Wrestler extends Character {
     )
     private Set<Match> matches;
 
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name="imageSetId", referencedColumnName = "id")
+    private ImageSet imageSet;
+
     @CreationTimestamp
     private Timestamp createdAt;
 
 
     @Builder
     public Wrestler(String announceName, String firstName, String lastName, WrestlerAttributes wrestlerAttributes,
-                    byte[] imageData, byte[] defeatedImage, User user, Set<Match> matches)
+                    ImageSet imageSet, User user, Set<Match> matches)
     {
-        super(announceName, firstName, lastName, wrestlerAttributes, imageData, defeatedImage);
+        super(announceName, firstName, lastName, wrestlerAttributes);
         this.user = user;
         this.matches = matches;
+        this.imageSet = imageSet;
     }
 
 }

--- a/src/main/java/com/efederation/Repository/ImageSetRepository.java
+++ b/src/main/java/com/efederation/Repository/ImageSetRepository.java
@@ -1,0 +1,10 @@
+package com.efederation.Repository;
+
+import com.efederation.Model.ImageSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageSetRepository extends JpaRepository<ImageSet, Long> {
+
+}

--- a/src/main/java/com/efederation/Service/ImageSetService.java
+++ b/src/main/java/com/efederation/Service/ImageSetService.java
@@ -1,0 +1,9 @@
+package com.efederation.Service;
+
+import com.efederation.DTO.ImageSetCreateRequest;
+
+import java.io.IOException;
+
+public interface ImageSetService {
+    String createImageSet(ImageSetCreateRequest request) throws IOException;
+}

--- a/src/main/java/com/efederation/Service/NPCService.java
+++ b/src/main/java/com/efederation/Service/NPCService.java
@@ -13,5 +13,5 @@ public interface NPCService {
 
     void updateNPCJsonAttributes(long npcId);
 
-    void uploadImage(long npcId, MultipartFile file, ImageType uploadType);
+    //void uploadImage(long npcId, MultipartFile file, ImageType uploadType);
 }

--- a/src/main/java/com/efederation/Service/WrestlerService.java
+++ b/src/main/java/com/efederation/Service/WrestlerService.java
@@ -13,5 +13,5 @@ public interface WrestlerService {
 
     void updateWrestlerJsonAttributes(long wrestlerId);
 
-    void uploadImage(WrestlerImageCreateRequest request);
+    //void uploadImage(WrestlerImageCreateRequest request);
 }

--- a/src/main/java/com/efederation/Service/impl/ImageSetServiceImpl.java
+++ b/src/main/java/com/efederation/Service/impl/ImageSetServiceImpl.java
@@ -1,0 +1,32 @@
+package com.efederation.Service.impl;
+
+import com.efederation.Constants.CommonConstants;
+import com.efederation.DTO.ImageSetCreateRequest;
+import com.efederation.Model.ImageSet;
+import com.efederation.Repository.ImageSetRepository;
+import com.efederation.Service.ImageSetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class ImageSetServiceImpl implements ImageSetService {
+
+    @Autowired
+    ImageSetRepository imageSetRepository;
+    public String createImageSet(ImageSetCreateRequest request) throws IOException {
+        ImageSet newImageSet = ImageSet
+                .builder()
+                .setName(request.getName())
+                .idleImage(request.getIdle().getBytes())
+                .defeatedImage(request.getDefeated().getBytes())
+                .attackFrame1(request.getAttackOne().getBytes())
+                .attackFrame2(request.getAttackTwo().getBytes())
+                .attackFrame3(request.getAttackThree().getBytes())
+                .attackFrame4(request.getAttackFour().getBytes())
+                .build();
+        imageSetRepository.save(newImageSet);
+        return CommonConstants.success;
+    }
+}

--- a/src/main/java/com/efederation/Service/impl/MatchServiceImpl.java
+++ b/src/main/java/com/efederation/Service/impl/MatchServiceImpl.java
@@ -174,9 +174,9 @@ public class MatchServiceImpl implements MatchService {
             optionalWrestler.ifPresent(wrestler -> optionalNPC.ifPresent(npc -> {
                     modifiableMap.put("participants", String.format(CommonConstants.PARTICIPANT_VS, wrestler.getAnnounceName(), npc.getAnnounceName()));
                     if(Objects.equals(npc.getAnnounceName(), modifiableMap.get("winner").toString())) {
-                        modifiableMap.put("defeatedImage", wrestler.getDefeatedImage());
+                        modifiableMap.put("defeatedImage", wrestler.getImageSet().getDefeatedImage());
                     } else {
-                        modifiableMap.put("defeatedImage", npc.getDefeatedImage());
+                        modifiableMap.put("defeatedImage", npc.getImageSet().getDefeatedImage());
                     }
                 }
             ));


### PR DESCRIPTION
This work unifies all wrestler and npc images (defeated, attack, idle, etc.) under common archetypes saved as entities to the db and both will now reference these archetypes in a one-direction one-to-one relationship character -> imageSet.